### PR TITLE
Added bottom margin to .ref class for some breathing room

### DIFF
--- a/layouts/default/assets/style.css
+++ b/layouts/default/assets/style.css
@@ -418,5 +418,6 @@ div .ref {
   border: 1px solid #E8E8E8;
   background-color: #FBFBDD;
   padding: .5em 1em;
+  margin-bottom: 1.5em;
   max-width: 580px;
 }


### PR DESCRIPTION
If you look at the book at a single-page HTML, the .ref sections at the end of each chapter are flush against the next heading. Added a margin-bottom to them for some breathing room.
